### PR TITLE
fix: deprecation warnings

### DIFF
--- a/charm.rb
+++ b/charm.rb
@@ -6,7 +6,6 @@ class Charm < Formula
   desc "Manage your Charm account and encrypt/decrypt data"
   homepage "https://charm.sh/"
   version "0.8.6"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/charmbracelet/charm/releases/download/v0.8.6/charm_0.8.6_Darwin_x86_64.tar.gz"

--- a/glow.rb
+++ b/glow.rb
@@ -6,7 +6,6 @@ class Glow < Formula
   desc "Render markdown on the CLI"
   homepage "https://charm.sh/"
   version "1.4.1"
-  bottle :unneeded
 
   if OS.mac? && Hardware::CPU.intel?
     url "https://github.com/charmbracelet/glow/releases/download/v1.4.1/glow_1.4.1_Darwin_x86_64.tar.gz"


### PR DESCRIPTION
fixes this warning:

```
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the charmbracelet/tap tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/charmbracelet/homebrew-tap/charm.rb:9

Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the charmbracelet/tap tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/charmbracelet/homebrew-tap/glow.rb:9
```

this is already fixed on goreleaser, so new releases wont have this issue... 

closes #3